### PR TITLE
Compilation errors with Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,5 +163,24 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <!-- Java 7 compatibility -->
+      <id>default-tools7.jar</id>
+      <activation>
+        <property>
+          <name>java.vendor</name>
+          <value>Oracle Corporation</value>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <version>1.7.0</version>
+          <scope>system</scope>
+          <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
maven-stapler-plugin fails to compile with Java 7, here is a patch fixing this issue (the patch was written by James Pages for the maven-stapler-plugin Debian package)
