### PR TITLE
Remove jaxen from dependabot exclusion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
     open-pull-requests-limit: 10
     target-branch: master
     ignore:
-      # Ignore 1.2.0-atlassian-2
-      - dependency-name: "jaxen:jaxen"
       # maven core artifacts are provided by the running maven, do not update to prevent consuming something unavailable
       - dependency-name: "org.apache.maven:*"
   - package-ecosystem: github-actions


### PR DESCRIPTION
With 2.0.0, 1.2.0 should no longer be picked up.